### PR TITLE
Add nextclade v3.21.1 binary to Docker image

### DIFF
--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -5,16 +5,11 @@ FROM python:3.10-slim-bookworm
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
-    postgresql-client \
-    gcc \
     python3-dev \
-    libpq-dev \
     git \
     wget \
-    build-essential \
     ca-certificates \
-    sudo \
-    && rm -rf /var/lib/apt/lists/*
+    sudo
 
 WORKDIR /HOME
 RUN git clone https://github.com/IRS-Project/soar-usher.git

--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -5,11 +5,16 @@ FROM python:3.10-slim-bookworm
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
+    postgresql-client \
+    gcc \
     python3-dev \
+    libpq-dev \
     git \
     wget \
+    build-essential \
     ca-certificates \
-    sudo
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /HOME
 RUN git clone https://github.com/IRS-Project/soar-usher.git
@@ -20,5 +25,9 @@ WORKDIR /HOME/soar-usher/build
 RUN wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/faSomeRecords \
     && wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/faSize \
     && chmod +x faSomeRecords faSize
+
+RUN wget -q "https://github.com/nextstrain/nextclade/releases/download/v3.21.1/nextclade-x86_64-unknown-linux-musl" \
+    -O /HOME/soar-usher/build/nextclade \
+    && chmod +x /HOME/soar-usher/build/nextclade
 
 ENV PATH="/HOME/soar-usher/build:${PATH}"


### PR DESCRIPTION
## Summary

- Adds nextclade v3.21.1 static binary to the soar-usher Docker image
- Binary is downloaded from the official Nextstrain GitHub releases and placed in `/HOME/soar-usher/build/` (already on `$PATH`)

## Test plan

- Rebuild the Docker image and verify `nextclade --version` returns `3.21.1`